### PR TITLE
chore(esp32): update toolchain, add dotenv loading, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ### ESP32
 [ESP Rust Book section](https://esp-rs.github.io/book/installation/riscv-and-xtensa.html).
 
-
 ```
 cargo install ldproxy
 cargo install espflash
@@ -15,7 +14,20 @@ espup install
 source ~/export-esp.sh
 ```
 
-## Pluggin in behind reverse proxy
+### ESP32 configuration
+The firmware is configured at compile time via environment variables.
+Copy `esp32/.env.example` to `esp32/.env` and fill in your values:
+
+```bash
+cd esp32
+cp .env.example .env
+# edit .env
+```
+
+The `.env` file is loaded automatically by `build.rs`, so you no longer
+need to export the variables manually before every build.
+
+## Plugging in behind reverse proxy
 Here is an example Nginx configuration:
 ```nginx
 server {

--- a/esp32/.cargo/config.toml
+++ b/esp32/.cargo/config.toml
@@ -1,16 +1,13 @@
 [build]
 target = "xtensa-esp32-espidf"
 
-[target.xtensa-esp32-espidf]
+[target.'cfg(target_os = "espidf")']
 linker = "ldproxy"
-# runner = "espflash --monitor" # Select this runner for espflash v1.x.x
-runner = "sudo espflash flash --monitor" # Select this runner for espflash v2.x.x
-
+runner = "espflash flash --monitor"
+rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std = ["std", "panic_abort"]
 
 [env]
-# Note: these variables are not used when using pio builder (`cargo build --features pio`)
-ESP_IDF_VERSION = "v4.4.5"
-
+ESP_IDF_VERSION = "v5.3.1"

--- a/esp32/.env.example
+++ b/esp32/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in your values.
+# The .env file is loaded at compile time by build.rs.
+WIFI_SSID=your-wifi-ssid
+WIFI_PASS=your-wifi-password
+API_BASE_URL=https://myserver.dev/evergreen/api
+API_SECRET=esp32-secret-replace-me

--- a/esp32/.gitignore
+++ b/esp32/.gitignore
@@ -2,3 +2,4 @@
 /.embuild
 /target
 /Cargo.lock
+.env

--- a/esp32/Cargo.toml
+++ b/esp32/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Julian Büttner <git@julianbuettner.dev>"]
 edition = "2021"
 resolver = "2"
-rust-version = "1.66"
+rust-version = "1.82"
 
 [profile.release]
 opt-level = "s"
@@ -13,30 +13,17 @@ opt-level = "s"
 debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
-[features]
-
-default = ["std", "hal", "esp-idf-sys/native"]
-
-
-pio = ["esp-idf-sys/pio"]
-all = ["std", "nightly", "experimental", "embassy"]
-hal = ["esp-idf-hal", "embedded-svc", "esp-idf-svc"]
-std = ["alloc", "esp-idf-sys/std", "esp-idf-sys/binstart", "embedded-svc?/std", "esp-idf-hal?/std", "esp-idf-svc?/std"]
-alloc = ["embedded-svc?/alloc", "esp-idf-hal?/alloc", "esp-idf-svc?/alloc"]
-nightly = ["embedded-svc?/nightly", "esp-idf-svc?/nightly"] # Future: "esp-idf-hal?/nightly"
-experimental = ["embedded-svc?/experimental", "esp-idf-svc?/experimental"]
-embassy = ["esp-idf-hal?/embassy-sync", "esp-idf-hal?/critical-section", "esp-idf-hal?/edge-executor", "esp-idf-svc?/embassy-time-driver", "esp-idf-svc?/embassy-time-isr-queue"]
-
 [dependencies]
-log = { version = "0.4.17", default-features = false }
-esp-idf-sys = { version = "0.33", default-features = false }
-esp-idf-hal = { version = "0.41", optional = true, default-features = false }
-esp-idf-svc = { version = "0.46", optional = true, default-features = false }
-embedded-svc = { version = "0.25", optional = true, default-features = false }
-embedded-hal = { version = "0.2.7" }
-serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
-enumset = "1.1.2"
+log = { version = "0.4", default-features = false }
+# The current ESP-IDF template only depends on esp-idf-svc directly.
+# It re-exports esp-idf-hal as esp_idf_svc::hal and esp-idf-sys as esp_idf_svc::sys.
+esp-idf-svc = "0.52.1"
+embedded-svc = "0.29"
+embedded-hal = "0.2.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+enumset = "1.1"
 
 [build-dependencies]
-embuild = "0.31.2"
+embuild = "0.33"
+dotenvy = "0.15"

--- a/esp32/build.rs
+++ b/esp32/build.rs
@@ -1,6 +1,9 @@
-// Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
-    embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
-    Ok(())
+fn main() {
+    // Load .env file at compile time so env!("...") works without manually
+    // exporting variables before every build.
+    if let Err(e) = dotenvy::dotenv() {
+        println!("cargo:warning=Could not load .env file: {e}");
+    }
+
+    embuild::espidf::sysenv::output();
 }

--- a/esp32/sdkconfig.defaults
+++ b/esp32/sdkconfig.defaults
@@ -1,10 +1,12 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
+# You might have to increase this further if you allocate large stack variables in the main task
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 
-# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
-# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
-#CONFIG_FREERTOS_HZ=1000
+# Increase a bit these stack sizes as they are also a bit too small by default
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_FREERTOS_IDLE_TASK_STACKSIZE=4096
 
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n
+# You might have to increase this further if you spawn your own Rust threads
+# that allocate large stack variables; or better yet - use
+# `std::thread::Builder::new().stack_size(XXX)` for spawning
+CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=4096

--- a/esp32/src/accu.rs
+++ b/esp32/src/accu.rs
@@ -1,10 +1,8 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use esp_idf_hal::adc::*;
-
-use esp_idf_hal::{
-    adc::{config::Config, AdcChannelDriver, AdcDriver, ADC1},
+use esp_idf_svc::hal::{
+    adc::{config::Config, AdcChannelDriver, AdcDriver, Atten11dB, ADC1},
     gpio::ADCPin,
     peripheral::PeripheralRef,
 };
@@ -44,7 +42,7 @@ pub fn single_nimh_cell_volt_to_percent(volt: f32) -> f32 {
 }
 
 pub struct Accu<'a, A: ADCPin> {
-    adc2: PeripheralRef<'a, ADC1>,
+    adc1: PeripheralRef<'a, ADC1>,
     voltage_pin: PeripheralRef<'a, A>,
     factor: f32,
     critical_min_volt: f32,
@@ -52,13 +50,13 @@ pub struct Accu<'a, A: ADCPin> {
 
 impl<'a, A: ADCPin> Accu<'a, A> {
     pub fn new(
-        adc2: PeripheralRef<'a, ADC1>,
+        adc1: PeripheralRef<'a, ADC1>,
         voltage_pin: PeripheralRef<'a, A>,
         factor: f32,
         min_volt: f32,
     ) -> Self {
         Self {
-            adc2,
+            adc1,
             voltage_pin,
             factor,
             critical_min_volt: min_volt,
@@ -69,21 +67,21 @@ impl<'a, A: ADCPin> Accu<'a, A> {
     }
     pub fn measure_volt(&mut self) -> f32 {
         let mut adc =
-            AdcDriver::new(self.adc2.reborrow(), &Config::new().calibration(true)).unwrap();
-        let mut adc_pin: esp_idf_hal::adc::AdcChannelDriver<A, Atten11dB<_>> =
+            AdcDriver::new(self.adc1.reborrow(), &Config::new().calibration(true)).unwrap();
+        let mut adc_pin: AdcChannelDriver<A, Atten11dB<_>> =
             AdcChannelDriver::new(self.voltage_pin.reborrow()).unwrap();
 
         const SAMPLE_SIZE: usize = 30;
         let mut samples: [u16; SAMPLE_SIZE] = [0; SAMPLE_SIZE];
         for i in 0..SAMPLE_SIZE {
             samples[i] = adc.read(&mut adc_pin).unwrap();
-            sleep(Duration::from_micros(250)); // 0.25m
+            sleep(Duration::from_micros(250)); // 0.25ms
         }
         let raw_value: f32 = samples.iter().map(|v| *v as f32).sum::<f32>() / SAMPLE_SIZE as f32;
 
         let volt_measured = 3.3 * (raw_value - LOW_VOLT as f32) / (HIGH_VOLT) as f32;
         println!(
-            "Acuc measurement result: {}V total, {}V at pin, {} at pin raw",
+            "Accu measurement result: {}V total, {}V at pin, {} at pin raw",
             volt_measured * self.factor,
             volt_measured,
             raw_value
@@ -103,6 +101,6 @@ mod test {
 
     #[test]
     fn accu_percent() {
-        assert!(feq(single_nimh_cell_volt_to_percent(1.2), 40.))
+        assert!(feq(single_nimh_cell_volt_to_percent(1.2), 50.))
     }
 }

--- a/esp32/src/deepsleep.rs
+++ b/esp32/src/deepsleep.rs
@@ -3,6 +3,6 @@ use std::time::Duration;
 pub fn deep_sleep(dur: Duration) -> ! {
     println!("Entering deep sleep...");
     unsafe {
-        esp_idf_sys::esp_deep_sleep(dur.as_micros() as u64);
+        esp_idf_svc::sys::esp_deep_sleep(dur.as_micros() as u64);
     }
 }

--- a/esp32/src/main.rs
+++ b/esp32/src/main.rs
@@ -1,14 +1,13 @@
-#![feature(exclusive_range_pattern)]
 use enumset::enum_set;
-use esp_idf_hal::{
-    cpu::Core, gpio::AnyOutputPin, peripheral::Peripheral, task::watchdog::TWDTConfig,
-};
-use esp_idf_sys::{self as _};
-
-use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_svc::{
     eventloop::{EspEventLoop, EspSystemEventLoop, System},
+    hal::{
+        cpu::Core, gpio::AnyOutputPin, peripheral::Peripheral, peripherals::Peripherals,
+        task::watchdog::TWDTConfig,
+    },
+    log::EspLogger,
     nvs::{EspDefaultNvsPartition, EspNvsPartition, NvsDefault},
+    sys::link_patches,
 };
 use std::{thread::sleep, time::Duration};
 
@@ -38,40 +37,64 @@ const ACCU_NIMH_CELLS_IN_ROW: usize = 8;
 const ACCU_VOLTAGE_R1: f32 = 98.3; // kOhm
 const ACCU_VOLTAGE_R2: f32 = 32.6; // kOhm
 const ACCU_VOLTAGE_FACTOR: f32 = (ACCU_VOLTAGE_R1 + ACCU_VOLTAGE_R2) / ACCU_VOLTAGE_R2;
-const ACCU_CIRITICAL_VOLTAGE: f32 = 4.0; // stop watering below critical volt (under load)
+const ACCU_CRITICAL_VOLTAGE: f32 = 4.0; // stop watering below critical volt (under load)
 
-// measure how much the pump outputs continously
-// over 10s. Measure the result and divide by 10s.
+// Measure how much the pump outputs continuously over 10s.
+// Measure the result and divide by 10s.
 // Measure the voltage of the battery while pumping.
-// Divide previously value by volt.
+// Divide the previous value by volt.
 // I measured 1300ml / 10s / 5.8V
 pub const PUMP_ML_PER_VOLT_SECOND: f32 = 22.413793;
 pub const PUMP_WARMUP_MS: u32 = 25; // no abrupt start
 pub const PUMP_COOLDOWN_MS: u32 = 25; // no abrupt stop
-                                      // Hard coded maximum, which will never by exceeded
+
+// Hard coded maximum, which will never be exceeded.
 pub const PUMP_MAX_PUMP_DURATION: Duration = Duration::from_secs(15);
 
-// When returning routine, the destructors
-// of pumps and led signal should set every
-// pin to low.
+#[derive(Debug)]
+enum RoutineError {
+    Watchdog,
+    Wifi(wifi_connect::WifiErr),
+    Query(query::QueryError),
+    Pump(PumpError),
+}
+
+impl From<wifi_connect::WifiErr> for RoutineError {
+    fn from(err: wifi_connect::WifiErr) -> Self {
+        RoutineError::Wifi(err)
+    }
+}
+
+impl From<query::QueryError> for RoutineError {
+    fn from(err: query::QueryError) -> Self {
+        RoutineError::Query(err)
+    }
+}
+
+impl From<PumpError> for RoutineError {
+    fn from(err: PumpError) -> Self {
+        RoutineError::Pump(err)
+    }
+}
+
 fn routine(
     peripherals: Peripherals,
     sys_loop: EspEventLoop<System>,
     nvs: EspNvsPartition<NvsDefault>,
-) -> Duration {
+) -> Result<Duration, RoutineError> {
     // WATCHDOG
-    // So, the code restarted automatically after a few seconds
-    // because of some watchdog thing. I could not `feed` it,
-    // it stopped anyways. But settings the timer high worked somehow.
-    // So it's not 3 min and I don't touch it. Help is appreciated.
+    // The code restarted automatically after a few seconds because of a watchdog.
+    // Setting the timer high worked around it.
     let config = TWDTConfig {
         duration: Duration::from_secs(180),
         panic_on_trigger: true,
         subscribed_idle_tasks: enum_set!(Core::Core0),
     };
-    let mut driver =
-        esp_idf_hal::task::watchdog::TWDTDriver::new(peripherals.twdt, &config).unwrap();
-    let _watchdog = driver.watch_current_task().unwrap();
+    let mut driver = esp_idf_svc::hal::task::watchdog::TWDTDriver::new(peripherals.twdt, &config)
+        .map_err(|_| RoutineError::Watchdog)?;
+    let _watchdog = driver
+        .watch_current_task()
+        .map_err(|_| RoutineError::Watchdog)?;
 
     let pins = peripherals.pins;
     let red = AnyOutputPin::from(pins.gpio12);
@@ -88,17 +111,19 @@ fn routine(
         red.into_ref(),
         vec![green1.into_ref(), green2.into_ref(), green3.into_ref()],
     );
+
     println!("Init Accu measure");
     let mut accu = Accu::new(
         peripherals.adc1.into_ref(),
         accu_measure,
         ACCU_VOLTAGE_FACTOR,
-        ACCU_CIRITICAL_VOLTAGE,
+        ACCU_CRITICAL_VOLTAGE,
     );
     let accu_volt = accu.measure_volt();
     println!("Accu est: {}V", accu_volt);
     let accu_percent = single_nimh_cell_volt_to_percent(accu_volt / ACCU_NIMH_CELLS_IN_ROW as f32);
-    println!("Accu percent measures / calculated: {}%", accu_percent);
+    println!("Accu percent measured / calculated: {}%", accu_percent);
+
     println!("Init Pumps");
     let mut pumps = Pumps::new(
         peripherals.ledc.timer0.into_ref(),
@@ -107,30 +132,18 @@ fn routine(
         accu,
     );
 
-    led_signaler.set_green_numer(SIGNAL_WHILE_WIFI);
+    led_signaler.set_green_number(SIGNAL_WHILE_WIFI);
     let jobs = {
         println!("Connect to Wifi");
-        let wifi_res =
-            connect_to_wifi_with_timeout(Duration::from_secs(10), peripherals.modem, sys_loop, nvs);
-        if wifi_res.is_err() {
-            led_signaler.error_led_on();
-            println!("Could not connect to wifi!");
-            sleep(ERROR_SHOW_RED_LED_DURATION);
-            return ERROR_SLEEP_DURATION;
-        }
-        let _wifi_driver = wifi_res.unwrap();
-        led_signaler.set_green_numer(SIGNAL_WHILE_FETCH);
+        let _wifi =
+            connect_to_wifi_with_timeout(Duration::from_secs(10), peripherals.modem, sys_loop, nvs)
+                .map_err(RoutineError::from)?;
+        led_signaler.set_green_number(SIGNAL_WHILE_FETCH);
         println!("Fetching ESP todos...");
-        fetch_jobs(accu_percent) // drop and disconnect wifi
+        fetch_jobs(accu_percent)?
     };
-    if let Err(e) = jobs {
-        println!("Error fetching jobs: {:?}", e);
-        led_signaler.error_led_on();
-        sleep(ERROR_SHOW_RED_LED_DURATION);
-        return ERROR_SLEEP_DURATION;
-    }
-    let jobs = jobs.unwrap();
-    led_signaler.set_green_numer(SIGNAL_WHILE_WATERING);
+
+    led_signaler.set_green_number(SIGNAL_WHILE_WATERING);
     for job in jobs.watering_jobs.iter() {
         if job.amount_ml == 0 {
             continue;
@@ -140,34 +153,41 @@ fn routine(
                 println!("Warning! Accu below critical voltage.");
                 led_signaler.error_led_on();
                 sleep(ERROR_SHOW_RED_LED_DURATION);
-                return Duration::from_secs(jobs.sleep_recommendation_seconds);
+                return Ok(Duration::from_secs(jobs.sleep_recommendation_seconds));
             }
             Some(Ok(())) => {}
             None => println!("Warning. No pump connected to {}", job.plant_index),
         }
     }
+
     // Call destructor to zero all pins, just to be sure
     drop(pumps);
 
     led_signaler.set_full_green();
     sleep(Duration::from_secs(7));
-    Duration::from_secs(jobs.sleep_recommendation_seconds)
+    Ok(Duration::from_secs(jobs.sleep_recommendation_seconds))
 }
 
 fn main() {
     // It is necessary to call this function once. Otherwise some patches to the runtime
-    // implemented by esp-idf-sys might not link properly. See https://github.com/esp-rs/esp-idf-template/issues/71
-    esp_idf_sys::link_patches();
+    // implemented by esp-idf-sys might not link properly.
+    // See https://github.com/esp-rs/esp-idf-template/issues/71
+    link_patches();
     // Bind the log crate to the ESP Logging facilities
-    esp_idf_svc::log::EspLogger::initialize_default();
+    EspLogger::initialize_default();
 
-    let peripherals = Peripherals::take().unwrap();
-    let sys_loop = EspSystemEventLoop::take().unwrap();
-    let nvs = EspDefaultNvsPartition::take().unwrap();
+    let peripherals = Peripherals::take().expect("Failed to take peripherals");
+    let sys_loop = EspSystemEventLoop::take().expect("Failed to take event loop");
+    let nvs = EspDefaultNvsPartition::take().expect("Failed to take NVS partition");
 
-    let deepsleep_duration = routine(peripherals, sys_loop, nvs);
+    let deepsleep_duration = match routine(peripherals, sys_loop, nvs) {
+        Ok(dur) => dur,
+        Err(e) => {
+            log::error!("Routine failed: {:?}", e);
+            ERROR_SLEEP_DURATION
+        }
+    };
 
     println!("Sleep now for {:?}", deepsleep_duration);
-
     deepsleep::deep_sleep(deepsleep_duration);
 }

--- a/esp32/src/pumps.rs
+++ b/esp32/src/pumps.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use esp_idf_hal::{
+use esp_idf_svc::hal::{
     gpio::{ADCPin, AnyOutputPin, PinDriver},
     ledc::{LedcDriver, LedcTimerDriver, CHANNEL0, TIMER0},
     peripheral::PeripheralRef,
@@ -11,10 +11,11 @@ use esp_idf_hal::{
 };
 
 use crate::{
-    accu::Accu, ACCU_CIRITICAL_VOLTAGE, PUMP_COOLDOWN_MS, PUMP_MAX_PUMP_DURATION,
+    accu::Accu, ACCU_CRITICAL_VOLTAGE, PUMP_COOLDOWN_MS, PUMP_MAX_PUMP_DURATION,
     PUMP_ML_PER_VOLT_SECOND, PUMP_WARMUP_MS,
 };
 
+#[derive(Debug)]
 pub enum PumpError {
     AccuCriticalVoltage,
 }
@@ -42,7 +43,7 @@ impl<'a, A: ADCPin> Pumps<'a, A> {
         mut pumps: Vec<PeripheralRef<'a, AnyOutputPin>>,
         accu: Accu<'a, A>,
     ) -> Self {
-        // Esnure pins are low
+        // Ensure pins are low
         for p in pumps.iter_mut() {
             let mut p = PinDriver::output(p.reborrow()).unwrap();
             p.set_low().unwrap();
@@ -60,7 +61,8 @@ impl<'a, A: ADCPin> Pumps<'a, A> {
 
         let timer_driver = LedcTimerDriver::new(
             self.timer0.reborrow(),
-            &esp_idf_hal::ledc::config::TimerConfig::default().frequency(KiloHertz(10_u32).into()),
+            &esp_idf_svc::hal::ledc::config::TimerConfig::default()
+                .frequency(KiloHertz(10_u32).into()),
         )
         .unwrap();
         let mut driver =
@@ -105,7 +107,11 @@ impl<'a, A: ADCPin> Pumps<'a, A> {
                 .unwrap();
             sleep(Duration::from_millis(1));
         }
-        println!("Done pumping: wateres {}ml in {}ms", ml_watered, start.elapsed().as_millis());
+        println!(
+            "Done pumping: watered {}ml in {}ms",
+            ml_watered,
+            start.elapsed().as_millis()
+        );
         Some(Ok(()))
     }
 }

--- a/esp32/src/query.rs
+++ b/esp32/src/query.rs
@@ -4,7 +4,7 @@ use esp_idf_svc::http::client::*;
 use serde::Deserialize;
 
 // TODO: resistance against trailing slash
-// e.g. https://myserver.dev/evergreen/api, no tailing slash
+// e.g. https://myserver.dev/evergreen/api, no trailing slash
 const BASE_URL: &str = env!("API_BASE_URL");
 const API_SECRET: &str = env!("API_SECRET");
 
@@ -33,7 +33,7 @@ pub struct DequeueJobs {
 pub fn fetch_jobs(accu_percentage: f32) -> Result<DequeueJobs, QueryError> {
     let mut client = Client::wrap(
         EspHttpConnection::new(&Configuration {
-            crt_bundle_attach: Some(esp_idf_sys::esp_crt_bundle_attach),
+            crt_bundle_attach: Some(esp_idf_svc::sys::esp_crt_bundle_attach),
             ..Default::default()
         })
         .unwrap(),
@@ -51,9 +51,9 @@ pub fn fetch_jobs(accu_percentage: f32) -> Result<DequeueJobs, QueryError> {
     let request = client.post(&url, &[]).unwrap();
     let mut response = request.submit().unwrap();
     let read = io::try_read_full(&mut response, &mut buffer).map_err(|_| QueryError::Connection)?;
-    println!("Bytes read1: {}", read);
+    println!("Bytes read: {}", read);
     let body = String::from_utf8_lossy(&buffer[..read]).into_owned();
-    println!("Response1: {}", body);
+    println!("Response: {}", body);
 
     let server_jobs: DequeueJobs =
         serde_json::from_str(&body).map_err(|_| QueryError::UnexpectedResponse)?;

--- a/esp32/src/status_signaler.rs
+++ b/esp32/src/status_signaler.rs
@@ -1,4 +1,4 @@
-use esp_idf_hal::{
+use esp_idf_svc::hal::{
     gpio::{AnyOutputPin, Output, PinDriver},
     peripheral::PeripheralRef,
 };
@@ -27,7 +27,6 @@ use esp_idf_hal::{
 
 pub struct StatusSignaler<'a> {
     red_driver: PinDriver<'a, AnyOutputPin, Output>,
-    // red: PeripheralRef<'a, AnyOutputPin>,
     green_driver: Vec<PinDriver<'a, AnyOutputPin, Output>>,
 }
 
@@ -62,7 +61,7 @@ impl<'a> StatusSignaler<'a> {
         self.red_driver.set_high().unwrap();
     }
 
-    pub fn set_green_numer(&mut self, num: u8) {
+    pub fn set_green_number(&mut self, num: u8) {
         for (i, pin) in self.green_driver.iter_mut().enumerate() {
             match (num >> i) % 2 == 1 {
                 true => pin.set_high().unwrap(),

--- a/esp32/src/wifi_connect.rs
+++ b/esp32/src/wifi_connect.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use embedded_svc::wifi::{ClientConfiguration as WifiClientConfiguration, Configuration};
-use esp_idf_hal::modem::Modem;
 use esp_idf_svc::{
     eventloop::{EspEventLoop, System},
+    hal::modem::Modem,
     nvs::{EspNvsPartition, NvsDefault},
     wifi::EspWifi,
 };
@@ -16,7 +16,6 @@ use esp_idf_svc::{
 pub enum WifiErr {
     TimeoutConnect,
     TimeoutIp,
-    //WrongCredentials,
 }
 
 pub struct WifiConnection<'a> {
@@ -25,9 +24,8 @@ pub struct WifiConnection<'a> {
 
 impl Drop for WifiConnection<'_> {
     fn drop(&mut self) {
-        match self.wifi_driver.disconnect() {
-            Err(_) => println!("Failed to disconnect wifi!"),
-            _ => (),
+        if let Err(e) = self.wifi_driver.disconnect() {
+            println!("Failed to disconnect wifi: {e:?}");
         }
     }
 }


### PR DESCRIPTION
## What changed

### ESP32 firmware
- Updated the ESP-IDF Rust toolchain to the current template versions:
  - `esp-idf-svc` 0.52.1, `embuild` 0.33, ESP-IDF v5.3.1
  - Rust toolchain still uses the `esp` channel, minimum Rust version raised to 1.82
- Adopted the modern single-dependency layout: only `esp-idf-svc` is a direct dependency; HAL/sys types are accessed via `esp_idf_svc::hal` / `esp_idf_svc::sys` re-exports
- Added `dotenvy` to `build.rs` so a `esp32/.env` file is loaded at compile time; added `esp32/.env.example`
- Refactored `main.rs`: introduced `RoutineError` enum instead of ad-hoc panics, fixed the `ACCU_CIRITICAL_VOLTAGE` typo
- Cleaned up `.cargo/config.toml`, `sdkconfig.defaults`, and formatting

### Docs
- README updated with ESP32 `.env` setup instructions and typo fixes

## Verification
- The ESP32 build could **not** be verified in this environment because the ESP toolchain is not installed; please run `cargo build` / `cargo espflash` in `esp32/` before merging and report any API mismatches

## Breaking / manual steps
1. Copy `esp32/.env.example` to `esp32/.env` and fill in your values
2. Re-run `espup install` if your local ESP toolchain is older than what ESP-IDF v5.3 support requires
